### PR TITLE
Fix autoscrolling issue with line limit;

### DIFF
--- a/SampleForm/Form1.cs
+++ b/SampleForm/Form1.cs
@@ -188,7 +188,7 @@ namespace SampleForm
         private void BtnLogLimit_Click(object sender, EventArgs e)
         {
             bool limitEnabled = _options.MaxLogLines != int.MaxValue;
-            _options.MaxLogLines = limitEnabled ? 0 : 5;
+            _options.MaxLogLines = limitEnabled ? 0 : 35;
             btnLogLimit.Text = limitEnabled ? "Enable Line Limit" : "Disable Line Limit";
             Log.Information("Log line limit set to {lineLimit}", _options.MaxLogLines == int.MaxValue ? "Maximum" : _options.MaxLogLines);
         }

--- a/Serilog.Sinks.RichTextBox.WinForms/Sinks/RichTextBoxForms/Extensions/RichTextBoxExtensions.cs
+++ b/Serilog.Sinks.RichTextBox.WinForms/Sinks/RichTextBoxForms/Extensions/RichTextBoxExtensions.cs
@@ -80,9 +80,6 @@ namespace Serilog.Sinks.RichTextBoxForms.Extensions
                 richTextBox.SelectionStart = 0;
                 richTextBox.SelectionLength = richTextBox.Lines[..^maxLogLines].Sum(line => line.Length + 1);
                 richTextBox.SelectedText = NullCharacter;
-                scrollPoint = Point.Empty;
-                previousSelection = 0;
-                previousLength = 0;
             }
 
             if (autoScroll == false)

--- a/Serilog.Sinks.RichTextBox.WinForms/Sinks/RichTextBoxForms/Extensions/RichTextBoxExtensions.cs
+++ b/Serilog.Sinks.RichTextBox.WinForms/Sinks/RichTextBoxForms/Extensions/RichTextBoxExtensions.cs
@@ -93,6 +93,7 @@ namespace Serilog.Sinks.RichTextBoxForms.Extensions
             }
             else
             {
+                richTextBox.SelectionStart = richTextBox.TextLength;
                 richTextBox.ScrollToCaret();
             }
 


### PR DESCRIPTION
Ref. #8 

- Sets the cursor to the last character in the control before invoking `ScrollToCaret()`
- Increase `MaxLogLines` to 35 in the demo application to illustrate that the fix is working