### PR TITLE
Fix RichTextBox sink event loss during disposal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v5
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: 8.0.x
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Restore dependencies
       run: dotnet restore
@@ -39,7 +39,7 @@ jobs:
         title: 'Code Coverage Report'
 
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: coverage-report
         path: './coverage/report'

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.2.0" />
-        <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
+        <PackageReference Include="System.Resources.Extensions" Version="10.0.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Serilog.Sinks.RichTextBox.WinForms.Colored.Test/Integration/SinkLifecycleTests.cs
+++ b/Serilog.Sinks.RichTextBox.WinForms.Colored.Test/Integration/SinkLifecycleTests.cs
@@ -2,12 +2,28 @@ using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.RichTextBoxForms;
 using Serilog.Sinks.RichTextBoxForms.Themes;
+using System.Windows.Forms;
 using Xunit;
 
 namespace Serilog.Tests.Integration
 {
     public class SinkLifecycleTests : RichTextBoxSinkTestBase
     {
+        [Fact]
+        public void Dispose_DrainsEventsEmittedBeforeDisposal()
+        {
+            _ = _richTextBox.Handle;
+
+            _sink.Emit(CreateEvent("first"));
+            _sink.Emit(CreateEvent("second"));
+            _sink.Dispose();
+
+            Application.DoEvents();
+
+            Assert.Contains("first", _richTextBox.Text);
+            Assert.Contains("second", _richTextBox.Text);
+        }
+
         [Fact]
         public void Dispose_CancelsMessageProcessing()
         {
@@ -44,6 +60,16 @@ namespace Serilog.Tests.Integration
                 }
                 testRichTextBox.Dispose();
             }
+        }
+
+        private static LogEvent CreateEvent(string message)
+        {
+            return new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Information,
+                null,
+                new MessageTemplate(new[] { new TextToken(message) }),
+                Array.Empty<LogEventProperty>());
         }
     }
 }

--- a/Serilog.Sinks.RichTextBox.WinForms.Colored.Test/Serilog.Sinks.RichTextBox.WinForms.Colored.Test.csproj
+++ b/Serilog.Sinks.RichTextBox.WinForms.Colored.Test/Serilog.Sinks.RichTextBox.WinForms.Colored.Test.csproj
@@ -14,14 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Serilog.Sinks.RichTextBox.WinForms.Colored/Serilog.Sinks.RichTextBox.WinForms.Colored.csproj
+++ b/Serilog.Sinks.RichTextBox.WinForms.Colored/Serilog.Sinks.RichTextBox.WinForms.Colored.csproj
@@ -22,8 +22,9 @@
         <TargetFrameworks>net462;net471;net6.0-windows;net8.0-windows;net9.0-windows;netcoreapp3.0-windows;netcoreapp3.1-windows</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <UseWindowsForms>true</UseWindowsForms>
-        <Version>3.2.0</Version>
+        <Version>3.2.1</Version>
         <PackageReleaseNotes>
+- Fixed RichTextBox sink disposal dropping buffered log events.
 - Added support for JSON pretty-printing in log messages.
 
 See repository for more information:
@@ -48,12 +49,12 @@ https://github.com/vonhoff/Serilog.Sinks.RichTextBox.WinForms.Colored
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="[2.12.0,)"/>
+<PackageReference Include="Serilog" Version="[2.12.0,)" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net471' ">
-        <Reference Include="System.Drawing"/>
-        <Reference Include="System.Windows.Forms"/>
+        <Reference Include="System.Drawing" />
+        <Reference Include="System.Windows.Forms" />
     </ItemGroup>
 
 </Project>

--- a/Serilog.Sinks.RichTextBox.WinForms.Colored/Sinks/RichTextBoxForms/RichTextBoxSink.cs
+++ b/Serilog.Sinks.RichTextBox.WinForms.Colored/Sinks/RichTextBoxForms/RichTextBoxSink.cs
@@ -108,22 +108,19 @@ namespace Serilog.Sinks.RichTextBoxForms
             var flushInterval = TimeSpan.FromMilliseconds(FlushIntervalMs);
             var lastFlush = DateTime.MinValue;
 
-            while (!token.IsCancellationRequested)
+            while (true)
             {
                 _signal.WaitOne();
-                if (token.IsCancellationRequested)
-                {
-                    break;
-                }
+                var stopping = token.IsCancellationRequested;
 
-                var now = DateTime.UtcNow;
-                var elapsedSinceLastFlush = now - lastFlush;
-                if (elapsedSinceLastFlush < flushInterval)
+                if (!stopping)
                 {
-                    var remainingTime = flushInterval - elapsedSinceLastFlush;
-                    if (token.WaitHandle.WaitOne(remainingTime))
+                    var now = DateTime.UtcNow;
+                    var elapsedSinceLastFlush = now - lastFlush;
+                    if (elapsedSinceLastFlush < flushInterval)
                     {
-                        break;
+                        var remainingTime = flushInterval - elapsedSinceLastFlush;
+                        stopping = token.WaitHandle.WaitOne(remainingTime);
                     }
                 }
 
@@ -137,11 +134,42 @@ namespace Serilog.Sinks.RichTextBoxForms
 
                 if (_richTextBox.IsDisposed || _richTextBox.Disposing)
                 {
+                    if (stopping)
+                    {
+                        break;
+                    }
+
                     continue;
                 }
 
-                _richTextBox.SetRtf(builder.Rtf, _options.AutoScroll, token);
+                // There is no UI callback to queue if disposal happens before the
+                // control creates its handle.
+                if (stopping && !_richTextBox.IsHandleCreated)
+                {
+                    break;
+                }
+
+                // Drain the final snapshot before leaving so disposal does not drop
+                // events that are still in the buffer.
+                try
+                {
+                    _richTextBox.SetRtf(builder.Rtf, _options.AutoScroll, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    // Keep the final flush cancelable. The handle check above and
+                    // SetRtf's handle check are separate, so the handle can be
+                    // destroyed between them. A disposing control may never
+                    // recreate its handle, which would otherwise leave Dispose()
+                    // blocked in _processingTask.Wait().
+                    break;
+                }
                 lastFlush = DateTime.UtcNow;
+
+                if (stopping)
+                {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
The RichTextBox sink could display only the first of several rapidly emitted log events when the logger was immediately closed, especially when combined with the File sink.

This change drains the final buffered snapshot before stopping the sink’s processing task, preserving events emitted before disposal. It also adds regression coverage, and bumps the package version to 3.2.1
